### PR TITLE
Isolate configuration to affect only each instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,49 +1,72 @@
-var throwOnRootAccess = true;
 var ensurePosix = require('ensure-posix-path');
 
+/**
+ * Configures the module resolver. Empty options will reset to default settings
+ * @typedef {Object} Options
+ * @property {Bool} throwOnRootAccess whether to throw on
+ * @param  {Options} options
+ * @returns {Function} configured module resolver
+ */
 function resolveModules(options) {
-  options = options || {};
+  options || (options = {});
+  var throwOnRootAccess = true;
+  var moduleRoot;
 
   if (options.throwOnRootAccess === false) {
     throwOnRootAccess = false;
   }
 
+
+  /**
+   * Module resolver for AMD transpiling (Babel)
+   * @param  {String} _child child path of module to resolve
+   * @param  {String} _name name path of module to resolve
+   * @returns {String} resolved module path
+   */
+  function moduleResolve(_child, _name) {
+    var child = ensurePosix(_child);
+    var name = ensurePosix(_name);
+    if (child.charAt(0) !== '.') {
+      return child;
+    }
+
+    var parts = child.split('/');
+    var nameParts = name.split('/');
+    var parentBase = nameParts.slice(0, -1);
+
+    for (var i = 0, l = parts.length; i < l; i++) {
+      var part = parts[i];
+
+      if (part === '..') {
+        if (parentBase.length === 0) {
+          if (throwOnRootAccess) {
+            throw new Error('Cannot access parent module of root');
+          } else {
+            continue;
+          }
+        }
+        parentBase.pop();
+      } else if (part === '.') {
+        continue;
+      } else {
+        parentBase.push(part);
+      }
+    }
+
+    return parentBase.join('/');
+  }
+
+  // parallel API - enable parallel babel transpilation for the moduleResolve function
+  moduleResolve._parallelBabel = {
+    requireFile: __filename,
+    buildUsing: 'resolveModules',
+    params: options
+  };
+
   return moduleResolve;
 }
 
-function moduleResolve(_child, _name) {
-  var child = ensurePosix(_child);
-  var name = ensurePosix(_name);
-  if (child.charAt(0) !== '.') { return child; }
-
-  var parts = child.split('/');
-  var nameParts = name.split('/');
-  var parentBase = nameParts.slice(0, -1);
-
-  for (var i = 0, l = parts.length; i < l; i++) {
-    var part = parts[i];
-
-    if (part === '..') {
-      if (parentBase.length === 0) {
-        if (throwOnRootAccess) {
-          throw new Error('Cannot access parent module of root');
-        } else {
-          continue;
-        }
-      }
-      parentBase.pop();
-    } else if (part === '.') {
-      continue;
-    } else { parentBase.push(part); }
-  }
-
-  return parentBase.join('/');
-}
-
-// parallel API - enable parallel babel transpilation for the moduleResolve function
-moduleResolve._parallelBabel = { requireFile: __dirname, useMethod: 'moduleResolve' };
-
 module.exports = {
-  moduleResolve: moduleResolve,
+  moduleResolve: resolveModules(),
   resolveModules: resolveModules
 };

--- a/test.js
+++ b/test.js
@@ -1,12 +1,13 @@
 'use strict';
 
 var expect = require('chai').expect;
+var path = require('path');
 var amd = require('./index');
 var moduleResolve = amd.moduleResolve;
 var resolveModules = amd.resolveModules;
 var ParallelApi = require('broccoli-babel-transpiler/lib/parallel-api');
 
-describe('module resolver', function () {
+describe('module resolver', function() {
   it('should resolve relative sibling', function() {
     expect(moduleResolve('./foo', 'example/bar')).to.eql('example/foo');
   });
@@ -21,32 +22,50 @@ describe('module resolver', function () {
 
   it('should throw parent module of root is accesed', function() {
     expect(function() {
-      return moduleResolve('../../bizz', 'example')
+      return moduleResolve('../../bizz', 'example');
     }).to.throw(/Cannot access parent module of root/);
   });
 
   it('should not throw if specified', function() {
     expect(function() {
-      var r = resolveModules({ throwOnRootAccess: false });
-      return r('../../bizz', 'example')
+      var resolver = resolveModules({ throwOnRootAccess: false });
+      return resolver('../../bizz', 'example');
     }).to.not.throw(/Cannot access parent module of root/);
   });
 });
 
 describe('parallel babel transpilation', function() {
+  var resolver;
+  var options;
+
+  beforeEach(function() {
+    options = { foo: 'bar', moduleRoot: 'baz' };
+    resolver = resolveModules(options);
+  });
+
   it('is setup correctly', function() {
-    expect(moduleResolve._parallelBabel).to.be.an('object');
-    expect(moduleResolve._parallelBabel.requireFile).to.eql(__dirname);
-    expect(moduleResolve._parallelBabel.useMethod).to.eql('moduleResolve');
+    expect(typeof resolver._parallelBabel).to.eql('object');
+    expect(resolver._parallelBabel.requireFile).to.eql(path.join(__dirname, 'index.js'));
+    expect(resolver._parallelBabel.buildUsing).to.eql('resolveModules');
+    expect(resolver._parallelBabel.params).to.deep.eql(options);
   });
 
   it('builds', function() {
-    expect(ParallelApi.buildFromParallelApiInfo(moduleResolve._parallelBabel)).to.eql(moduleResolve);
+    expect(ParallelApi.buildFromParallelApiInfo(resolver._parallelBabel).toString())
+      .to.eql(resolver.toString());
   });
 
   it('serializes and deserializes', function() {
-    var options = { resolveModuleSource: moduleResolve };
-    var serializedOptions = ParallelApi.serializeOptions(options);
-    expect(ParallelApi.deserializeOptions(serializedOptions)).to.eql(options);
+    var babelOptions = { resolveModuleSource: resolver };
+    var serializedOptions = ParallelApi.serializeOptions(babelOptions);
+    expect(ParallelApi.deserializeOptions(serializedOptions).toString()).to.eql(babelOptions.toString());
+  });
+
+  it('follows the parallel API', function() {
+    expect(ParallelApi.transformIsParallelizable({ resolveModuleSource: moduleResolve})).to.be.ok;
+  });
+
+  it('isolates options to each instance', function() {
+    expect(resolver._parallelBabel.params).to.not.eql(moduleResolve._parallelBabel.params);
   });
 });


### PR DESCRIPTION
This PR isolates the configuration of the resolver to only take effect on each instance rather than polluting other instances of the resolver.

It does so by using an [alternative parallel Babel API method](https://github.com/babel/broccoli-babel-transpiler#parallel-transpilation)