### PR TITLE
feat(moduleRoot): add option to pass module root

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var ensurePosix = require('ensure-posix-path');
  * Configures the module resolver. Empty options will reset to default settings
  * @typedef {Object} Options
  * @property {Bool} throwOnRootAccess whether to throw on
+ * @property {String} moduleRoot to use for each of the resolved modules
  * @param  {Options} options
  * @returns {Function} configured module resolver
  */
@@ -16,6 +17,9 @@ function resolveModules(options) {
     throwOnRootAccess = false;
   }
 
+  if (typeof options.moduleRoot === 'string') {
+    moduleRoot = options.moduleRoot;
+  }
 
   /**
    * Module resolver for AMD transpiling (Babel)
@@ -33,6 +37,10 @@ function resolveModules(options) {
     var parts = child.split('/');
     var nameParts = name.split('/');
     var parentBase = nameParts.slice(0, -1);
+    // Add moduleRoot if not already present
+    if (moduleRoot && nameParts[0] !== moduleRoot) {
+      parentBase = moduleRoot.split('/').concat(parentBase);
+    }
 
     for (var i = 0, l = parts.length; i < l; i++) {
       var part = parts[i];

--- a/test.js
+++ b/test.js
@@ -12,12 +12,27 @@ describe('module resolver', function() {
     expect(moduleResolve('./foo', 'example/bar')).to.eql('example/foo');
   });
 
+  it('should resolve relative sibling with moduleRoot', function() {
+    var resolver = resolveModules({ moduleRoot: 'base/dir' });
+    expect(resolver('./foo', 'example/bar')).to.eql('base/dir/example/foo');
+  });
+
   it('should resolve relative parent', function() {
     expect(moduleResolve('../foo', 'example/bar/baz')).to.eql('example/foo');
   });
 
+  it('should resolve relative parent with moduleRoot', function() {
+    var resolver = resolveModules({ moduleRoot: 'base/dir' });
+    expect(resolver('../foo', 'example/bar/baz')).to.eql('base/dir/example/foo');
+  });
+
   it('should be a pass through if absolute', function() {
     expect(moduleResolve('foo/bar', 'example/')).to.eql('foo/bar');
+  });
+
+  it('should be a pass through if absolute with moduleRoot', function() {
+    var resolver = resolveModules({ moduleRoot: 'base/dir' });
+    expect(resolver('foo/bar', 'example/')).to.eql('foo/bar');
   });
 
   it('should throw parent module of root is accesed', function() {


### PR DESCRIPTION
This PR adds an option to pass in module root for your resolved modules.
This is useful when you want to add a base name that is different from the resolved modules location.

Example usage:

```js
// My Addon
const babelTranspiler = require('broccoli-babel-transpiler');
const { resolveModules } = require('amd-name-resolver');

module.exports = {
  treeForPublic() {
    // Get host app's module prefix
    const { project } = this.app;
    const { modulePrefix } = project.config(process.env.EMBER_ENV);
    ...
    // Pass modulePrefix as moduleRoot
    const resolveModuleSource = resolveModules({ moduleRoot: modulePrefix });
    const transpiledFiles = babelTranspiler(files, {
      plugins: [
        [
          'transform-es2015-modules-amd',
          {
            strict: true,
            noInterop: true
          }
        ]
      ],
      moduleIds: true,
      resolveModuleSource,
      moduleRoot: modulePrefix
    });
  }
};
```

This is a follow-up to PR https://github.com/ember-cli/amd-name-resolver/pull/11