### PR TITLE
Implement `broccoli-babel-transpiler` caching API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var ensurePosix = require('ensure-posix-path');
+var hash = require('object-hash');
 
 /**
  * Configures the module resolver. Empty options will reset to default settings
@@ -63,6 +64,16 @@ function resolveModules(options) {
 
     return parentBase.join('/');
   }
+
+  // broccoli-babel-transpiler caching
+
+  moduleResolve.cacheKey = function() {
+    return hash(options);
+  };
+
+  moduleResolve.baseDir = function() {
+    return __dirname;
+  };
 
   // parallel API - enable parallel babel transpilation for the moduleResolve function
   moduleResolve._parallelBabel = {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "ensure-posix-path": "^1.0.1"
+    "ensure-posix-path": "^1.0.1",
+    "object-hash": "^1.3.1"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,6 +775,11 @@ object-assign@4.1.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-hash@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
+  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"


### PR DESCRIPTION
... so that it can be used with https://github.com/tleunen/babel-plugin-module-resolver without producing any warnings