### PR TITLE
Import `relative-module-paths` module from `ember-cli-babel`

### DIFF
--- a/relative-module-paths.js
+++ b/relative-module-paths.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const path = require('path');
+const ensurePosix = require('ensure-posix-path');
+const { moduleResolve } = require('./index');
+
+function getRelativeModulePath(modulePath) {
+  return ensurePosix(path.relative(process.cwd(), modulePath));
+}
+
+function resolveRelativeModulePath(name, child) {
+  return moduleResolve(name, getRelativeModulePath(child));
+}
+
+module.exports = {
+  getRelativeModulePath,
+  resolveRelativeModulePath
+};
+
+Object.keys(module.exports).forEach((key) => {
+  module.exports[key].baseDir = () => __dirname;
+
+  module.exports[key]._parallelBabel = {
+    requireFile: __filename,
+    useMethod: key
+  };
+});


### PR DESCRIPTION
This module is useful/needed when supporting Babel 7 and already duplicated in at least two places, so it makes sense to extract it into a common place.