### PR TITLE
Fix Windows issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function resolveModules(options) {
    */
   function moduleResolve(_child, _name) {
     var child = ensurePosix(_child);
-    var name = ensurePosix(_name);
+    var name = _name && ensurePosix(_name);
     if (child.charAt(0) !== '.') {
       return child;
     }


### PR DESCRIPTION
When `moduleResolve` is used as the `getModuleId` in Babel, it's called without a `name` parameter. This works find in *nix, where `ensurePosix` is a noop. On Windows, `ensurePosix` attempts to split `undefined` by `path.sep` and throws an exception. This change avoids calling `ensurePosix` when `_name` can't have `\` characters.